### PR TITLE
회원가입 구현[ISSUE-2]

### DIFF
--- a/back/src/main/java/com/t1dmlgus/daangnClone/BaseTimeEntity.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.t1dmlgus.daangnClone;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/config/JpaConfig.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.t1dmlgus.daangnClone.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserService.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserService.java
@@ -1,4 +1,10 @@
 package com.t1dmlgus.daangnClone.user.application;
 
+import com.t1dmlgus.daangnClone.user.ui.dto.JoinRequestDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+
 public interface UserService {
+
+    // 회원가입
+    ResponseDto<?> join(JoinRequestDto JoinRequestDto);
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserServiceImpl.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserServiceImpl.java
@@ -1,0 +1,29 @@
+package com.t1dmlgus.daangnClone.user.application;
+
+import com.t1dmlgus.daangnClone.user.domain.User;
+import com.t1dmlgus.daangnClone.user.domain.UserRepository;
+import com.t1dmlgus.daangnClone.user.ui.dto.JoinRequestDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl{
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ResponseDto<?> join(JoinRequestDto joinRequestDto) {
+
+        User user = joinRequestDto.toEntity();
+
+        User joinUser = userRepository.save(user);
+
+        return new ResponseDto<>("회원가입이 완료되었습니다.", joinUser.getId());
+    }
+
+
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/Role.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/Role.java
@@ -1,0 +1,10 @@
+package com.t1dmlgus.daangnClone.user.domain;
+
+import javax.persistence.Enumerated;
+
+
+public enum Role {
+
+    ROLE_USER,
+    ROLE_ADMIN
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/User.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/User.java
@@ -1,10 +1,7 @@
 package com.t1dmlgus.daangnClone.user.domain;
 
 import com.t1dmlgus.daangnClone.BaseTimeEntity;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import javax.persistence.*;
 
@@ -32,6 +29,19 @@ public class User extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+
+    @Builder
+    public User(String email, String password, String name, String phone, String nickName, Role role) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.nickName = nickName;
+        this.role = role;
+    }
+
+
 
 
 

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/User.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/User.java
@@ -1,4 +1,38 @@
 package com.t1dmlgus.daangnClone.user.domain;
 
-public class User {
+import com.t1dmlgus.daangnClone.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    private String name;
+
+    private String phone;
+
+    private String nickName;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+
+
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/UserRepository.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/UserRepository.java
@@ -1,4 +1,7 @@
 package com.t1dmlgus.daangnClone.user.domain;
 
-public interface UserRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/UserApiController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/UserApiController.java
@@ -1,7 +1,30 @@
 package com.t1dmlgus.daangnClone.user.ui;
 
+import com.t1dmlgus.daangnClone.user.application.UserService;
+import com.t1dmlgus.daangnClone.user.application.UserServiceImpl;
+import com.t1dmlgus.daangnClone.user.ui.dto.JoinRequestDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
 @RestController
 public class UserApiController {
+
+    private final UserServiceImpl userServiceImpl;
+
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> join(@RequestBody JoinRequestDto joinRequestDto){
+
+        ResponseDto<?> join = userServiceImpl.join(joinRequestDto);
+
+        return new ResponseEntity<>(join, HttpStatus.OK);
+    }
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/UserApiController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/UserApiController.java
@@ -25,6 +25,6 @@ public class UserApiController {
 
         ResponseDto<?> join = userServiceImpl.join(joinRequestDto);
 
-        return new ResponseEntity<>(join, HttpStatus.OK);
+        return new ResponseEntity<>(join, HttpStatus.CREATED);
     }
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/JoinRequestDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/JoinRequestDto.java
@@ -1,0 +1,35 @@
+package com.t1dmlgus.daangnClone.user.ui.dto;
+
+import com.t1dmlgus.daangnClone.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class JoinRequestDto {
+
+    private String email;
+
+    private String password;
+
+    private String name;
+
+    private String phone;
+
+    private String nickName;
+
+    public User toEntity(){
+
+        return User.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .phone(phone)
+                .nickName(nickName)
+                .build();
+    }
+
+
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/ResponseDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/ResponseDto.java
@@ -1,0 +1,14 @@
+package com.t1dmlgus.daangnClone.user.ui.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ResponseDto<T> {
+
+    private String message;
+    private T data;
+}

--- a/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
@@ -1,0 +1,49 @@
+package com.t1dmlgus.daangnClone.user.application;
+
+import com.t1dmlgus.daangnClone.user.domain.User;
+import com.t1dmlgus.daangnClone.user.domain.UserRepository;
+import com.t1dmlgus.daangnClone.user.ui.dto.JoinRequestDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplUnitTest {
+
+    @InjectMocks
+    private UserServiceImpl userServiceImpl;
+    @Mock
+    private UserRepository userRepository;
+    
+    
+    @DisplayName("회원가입 서비스 테스트")
+    @Test
+    public void joinTest() throws Exception{
+        //given
+
+        JoinRequestDto joinRequestDto = new JoinRequestDto("dmlgusgngl@gmail.com",
+                "1234", "이의현", "2232-1234", "t1dmlgus");
+        User user = joinRequestDto.toEntity();
+
+        doReturn(user).when(userRepository).save(any(User.class));
+
+        //when
+        ResponseDto<?> join = userServiceImpl.join(joinRequestDto);
+
+        //then
+        assertThat(join.getMessage()).isEqualTo("회원가입이 완료되었습니다.");
+    }
+
+
+}

--- a/back/src/test/java/com/t1dmlgus/daangnClone/user/ui/UserApiControllerUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/user/ui/UserApiControllerUnitTest.java
@@ -1,0 +1,68 @@
+package com.t1dmlgus.daangnClone.user.ui;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.t1dmlgus.daangnClone.user.application.UserServiceImpl;
+import com.t1dmlgus.daangnClone.user.ui.dto.JoinRequestDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(value = UserApiController.class)
+class UserApiControllerUnitTest {
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserServiceImpl userServiceImpl;
+
+
+    @BeforeEach
+    void setup(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .build();
+    }
+
+
+    @DisplayName("회원가입 컨트롤러 테스트")
+    @Test
+    public void ControllerJoinTest() throws Exception{
+        //given
+        JoinRequestDto joinRequestDto = new JoinRequestDto("dmlgusgngl@gmail.com",
+                "1234", "이의현", "2232-1234", "t1dmlgus");
+        String json = new ObjectMapper().writeValueAsString(joinRequestDto);
+
+
+        doReturn(new ResponseDto<>("회원가입이 완료되었습니다.", 1L))
+                .when(userServiceImpl).join(joinRequestDto);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/user/signup")
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."))
+                .andDo(print());
+
+    }
+}

--- a/back/src/test/java/com/t1dmlgus/daangnClone/user/ui/UserApiControllerUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/user/ui/UserApiControllerUnitTest.java
@@ -60,7 +60,7 @@ class UserApiControllerUnitTest {
 
         //then
         resultActions
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."))
                 .andDo(print());
 


### PR DESCRIPTION
### 이슈번호
resolved: #2 

### 개요

회원가입 구현 및 테스트
JPA Auditing 으로 생성시간, 수정시간 컬럼추가


### 작업 내용

BaseTimeEntity.java

- JPA Auditing 기능을 @EntityListener(AuditingEntityListener.class)을 통해 추가한다.
- 각 엔티티는 BaseTimeEntity를 상속받아, 생성시간, 수정 시간 컬럼 추가를 자동화한다.

UserServiceImpl

- UserService 를 상속받아 회원가입 서비스를 구현한다.
- JoinRequestDto 를 사용하여 회원가입 시 필요한 데이터(이메일, 비밀번호, 이름, 핸드폰번호, 닉네임)을 받아온다.
- ResponseDto, 공통 응답 Dto을 생성하여 해당 기능 리턴 값(메시지와 데이터)을 반환한다.

UserApiController

- POST, /api/user/signup url 요청 시 회원가입 컨트롤러를 구현한다.
- 회원가입 서비스 리턴값과, http 상태코드(201)을 반환한다.


### 테스트

- [x] UserServiceImplUnitTest
- [x] UserApiControllerUnitTest


### 주의사항

@ RequestBody

@EnableJpaAuditing