### PR TITLE
feat: 회원조회 기능 구현[ISSUE-5]

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.6'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/handler/exception/CustomApiException.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/handler/exception/CustomApiException.java
@@ -1,0 +1,8 @@
+package com.t1dmlgus.daangnClone.handler.exception;
+
+public class CustomApiException extends RuntimeException{
+
+    public CustomApiException(String message) {
+        super(message);
+    }
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/handler/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/handler/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.t1dmlgus.daangnClone.handler.exception;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomApiException.class)
+    public ResponseEntity<String> CustomApiException(CustomApiException e) {
+
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserService.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserService.java
@@ -7,4 +7,7 @@ public interface UserService {
 
     // 회원가입
     ResponseDto<?> join(JoinRequestDto JoinRequestDto);
+
+    // 회원조회
+    ResponseDto<?> enquiry(Long userId);
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserServiceImpl.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserServiceImpl.java
@@ -1,17 +1,20 @@
 package com.t1dmlgus.daangnClone.user.application;
 
+import com.t1dmlgus.daangnClone.handler.exception.CustomApiException;
 import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.domain.UserRepository;
 import com.t1dmlgus.daangnClone.user.ui.dto.JoinRequestDto;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.UserInquiryResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
 @RequiredArgsConstructor
-public class UserServiceImpl{
+public class UserServiceImpl implements UserService{
 
     private final UserRepository userRepository;
 
@@ -19,10 +22,22 @@ public class UserServiceImpl{
     public ResponseDto<?> join(JoinRequestDto joinRequestDto) {
 
         User user = joinRequestDto.toEntity();
-
         User joinUser = userRepository.save(user);
 
         return new ResponseDto<>("회원가입이 완료되었습니다.", joinUser.getId());
+    }
+
+
+    @Override
+    public ResponseDto<?> enquiry(Long userId) {
+
+        User enquiryUser = userRepository.findById(userId).orElseThrow(
+                () -> { return new CustomApiException("조회 할 회원이 없습니다.");});
+
+        ModelMapper modelMapper = new ModelMapper();
+        UserInquiryResponseDto mapper = modelMapper.map(enquiryUser, UserInquiryResponseDto.class);
+
+        return new ResponseDto<>("회원이 조회되었습니다.", mapper);
     }
 
 

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/UserApiController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/UserApiController.java
@@ -1,30 +1,34 @@
 package com.t1dmlgus.daangnClone.user.ui;
 
 import com.t1dmlgus.daangnClone.user.application.UserService;
-import com.t1dmlgus.daangnClone.user.application.UserServiceImpl;
 import com.t1dmlgus.daangnClone.user.ui.dto.JoinRequestDto;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
 @RestController
 public class UserApiController {
 
-    private final UserServiceImpl userServiceImpl;
+    private final UserService userService;
 
 
     @PostMapping("/signup")
     public ResponseEntity<?> join(@RequestBody JoinRequestDto joinRequestDto){
 
-        ResponseDto<?> join = userServiceImpl.join(joinRequestDto);
+        ResponseDto<?> joinUser = userService.join(joinRequestDto);
 
-        return new ResponseEntity<>(join, HttpStatus.CREATED);
+        return new ResponseEntity<>(joinUser, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<?> enquiryUser(@PathVariable Long userId) {
+
+        ResponseDto<?> enquiryUser = userService.enquiry(userId);
+
+        return new ResponseEntity<>(enquiryUser, HttpStatus.OK);
     }
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/UserInquiryResponseDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/UserInquiryResponseDto.java
@@ -1,0 +1,19 @@
+package com.t1dmlgus.daangnClone.user.ui.dto;
+
+import com.t1dmlgus.daangnClone.user.domain.Role;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class UserInquiryResponseDto {
+
+    private Long id;
+    private String name;
+    private String email;
+    private Role role;
+
+
+}

--- a/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
@@ -1,5 +1,7 @@
 package com.t1dmlgus.daangnClone.user.application;
 
+import com.t1dmlgus.daangnClone.handler.exception.CustomApiException;
+import com.t1dmlgus.daangnClone.user.domain.Role;
 import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.domain.UserRepository;
 import com.t1dmlgus.daangnClone.user.ui.dto.JoinRequestDto;
@@ -12,8 +14,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.when;
 import static org.mockito.Mockito.doReturn;
 
 
@@ -27,7 +33,7 @@ class UserServiceImplUnitTest {
     private UserRepository userRepository;
     
     
-    @DisplayName("회원가입 서비스 테스트")
+    @DisplayName("서비스 - 회원가입 테스트")
     @Test
     public void joinTest() throws Exception{
         //given
@@ -45,5 +51,35 @@ class UserServiceImplUnitTest {
         assertThat(join.getMessage()).isEqualTo("회원가입이 완료되었습니다.");
     }
 
+    @DisplayName("서비스 - 회원조회 테스트")
+    @Test
+    public void enquiryUserTest() throws Exception{
+        //given
+        User user1 = new User("dmlgusgngl@gmail.com", "1234", "이의현", "1234-1234", "t1dmlgus", Role.ROLE_USER);
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user1));
+
+        //when
+        ResponseDto<?> enquiryUser = userServiceImpl.enquiry(any(Long.class));
+
+        //then
+        assertThat(enquiryUser.getMessage()).isEqualTo("회원이 조회되었습니다.");
+
+    }
+
+    @DisplayName("서비스 - 회원조회 실패 테스트")
+    @Test
+    public void FailEnquiryUserTest() throws Exception{
+        //given
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        //when
+
+        //then
+        assertThatThrownBy(() -> userServiceImpl.enquiry(any(Long.class)))
+                .isInstanceOf(CustomApiException.class)
+                .hasMessage("조회 할 회원이 없습니다.");
+
+
+    }
 
 }

--- a/back/src/test/java/com/t1dmlgus/daangnClone/user/ui/UserApiControllerUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/user/ui/UserApiControllerUnitTest.java
@@ -1,9 +1,11 @@
 package com.t1dmlgus.daangnClone.user.ui;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.t1dmlgus.daangnClone.user.application.UserServiceImpl;
+import com.t1dmlgus.daangnClone.user.application.UserService;
+import com.t1dmlgus.daangnClone.user.domain.Role;
 import com.t1dmlgus.daangnClone.user.ui.dto.JoinRequestDto;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.UserInquiryResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,11 +17,15 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
 
 
 @WebMvcTest(value = UserApiController.class)
@@ -28,7 +34,7 @@ class UserApiControllerUnitTest {
     private MockMvc mockMvc;
 
     @MockBean
-    private UserServiceImpl userServiceImpl;
+    private UserService userService;
 
 
     @BeforeEach
@@ -36,11 +42,10 @@ class UserApiControllerUnitTest {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
                 .build();
     }
-
-
-    @DisplayName("회원가입 컨트롤러 테스트")
+    
+    @DisplayName("컨트롤러 - 회원가입 테스트")
     @Test
-    public void ControllerJoinTest() throws Exception{
+    public void JoinUserTest() throws Exception{
         //given
         JoinRequestDto joinRequestDto = new JoinRequestDto("dmlgusgngl@gmail.com",
                 "1234", "이의현", "2232-1234", "t1dmlgus");
@@ -48,7 +53,7 @@ class UserApiControllerUnitTest {
 
 
         doReturn(new ResponseDto<>("회원가입이 완료되었습니다.", 1L))
-                .when(userServiceImpl).join(joinRequestDto);
+                .when(userService).join(joinRequestDto);
 
         //when
         ResultActions resultActions = mockMvc.perform(
@@ -65,4 +70,29 @@ class UserApiControllerUnitTest {
                 .andDo(print());
 
     }
+
+
+    @DisplayName("컨트롤러 - 회원조회 테스트")
+    @Test
+    public void enquiryUserTest() throws Exception{
+        //given
+        UserInquiryResponseDto userInquiryResponseDto = new UserInquiryResponseDto(1L,"이의현","dmlgusgngl@gmail.com", Role.ROLE_USER);
+        doReturn(new ResponseDto<>("회원이 조회되었습니다.", userInquiryResponseDto))
+                .when(userService).enquiry(any(Long.class));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/user/{userId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        );
+        
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("회원이 조회되었습니다."))
+                .andDo(print());
+
+    }
+
 }


### PR DESCRIPTION
### 이슈번호
resolved: #5 

### 개요

회원조회 기능 구현

### 작업 내용

UserServiceImpl.java

- 회원조회 기능의  UserService.enquiry() 상속하여 구현
- findByid로 반환되는 Optional 객체에 대해 CustomApiException로 예외 처리
- ModelMapper를 사용하여 반환된 객체를 회원조회 응답 DTO로 변환

GlobalExceptionHandler.java

- 전역적으로 예외 처리 관리하는 핸들러를 구현
- @ExceptionHandler 로 지정한 Exception 클래스가 호출되면 해당 핸들러 실행

CustomApiException.java

- RuntimeException을 상속받아 구현
- 생성자를 통해 예외메시지를 인자로 예외 생성됨

UserInquiryResponseDto.java
- 회원조회 시 반환되는 데이터(회원번호, 이름, 이메일, 권한)

UserApiController.java

- @PathVariable로 조회하고자 하는 유저번호를 인자로 받음
- UserSevice로 반환된 회원조회 데이터와, 상태코드를 ResponseEntity로 반환



### 테스트

- [x] UserServiceImplUnitTest
- [x] UserControllerUnitTest


### 주의사항

+ ModelMapper 추가




