### PR TITLE
refactor: 회원가입 리펙토링[ISSUE-8]

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 	compileOnly 'org.projectlombok:lombok'

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'

--- a/back/src/main/java/com/t1dmlgus/daangnClone/config/SecurityConfig.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/config/SecurityConfig.java
@@ -1,0 +1,14 @@
+package com.t1dmlgus.daangnClone.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/config/SecurityConfig.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/config/SecurityConfig.java
@@ -1,14 +1,33 @@
 package com.t1dmlgus.daangnClone.config;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @EnableWebSecurity
-public class SecurityConfig {
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder(){
         return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http.csrf().disable();
+        http.authorizeRequests()
+                .antMatchers("/api/user/signup").permitAll()
+                .and()
+                .formLogin()
+                .defaultSuccessUrl("/", false);
+
+
+
+
+
+
     }
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/handler/aop/ValidationAdvice.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/handler/aop/ValidationAdvice.java
@@ -1,0 +1,45 @@
+package com.t1dmlgus.daangnClone.handler.aop;
+
+
+import com.t1dmlgus.daangnClone.handler.exception.CustomValidationException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Aspect
+public class ValidationAdvice {
+
+    @Around("execution(* com.t1dmlgus.daangnClone.user.ui.UserApiController.join(..))")
+    public Object joinAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable{
+
+        Object[] args = proceedingJoinPoint.getArgs();
+
+        for (Object arg : args) {
+            if (arg instanceof BindingResult) {
+                BindingResult bindingResult = (BindingResult) arg;
+
+                if (bindingResult.hasErrors()) {
+                    Map<String, String> errorMap = new HashMap<>();
+
+                    for (FieldError fieldError : bindingResult.getFieldErrors()) {
+                        errorMap.put(fieldError.getField(), fieldError.getDefaultMessage());
+
+                    }
+                    throw new CustomValidationException("유효성 검사 실패", errorMap);
+                }
+            }
+        }
+
+        return proceedingJoinPoint.proceed();
+
+
+    }
+
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/handler/exception/CustomValidationException.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/handler/exception/CustomValidationException.java
@@ -1,0 +1,17 @@
+package com.t1dmlgus.daangnClone.handler.exception;
+
+import java.util.Map;
+
+public class CustomValidationException extends RuntimeException {
+
+    private Map<String, String> errorMap;
+
+    public CustomValidationException(String message, Map<String, String> errorMap) {
+        super(message);
+        this.errorMap = errorMap;
+    }
+
+    public Map<String, String> getErrorMap() {
+        return errorMap;
+    }
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/handler/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/handler/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.t1dmlgus.daangnClone.handler.exception;
 
 
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,5 +14,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> CustomApiException(CustomApiException e) {
 
         return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(CustomValidationException.class)
+    public ResponseEntity<?> CustomValidationException(CustomValidationException e) {
+
+        return new ResponseEntity<>(new ResponseDto<>(e.getMessage(), e.getErrorMap()), HttpStatus.BAD_REQUEST);
     }
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserServiceImpl.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.t1dmlgus.daangnClone.user.application;
 
 import com.t1dmlgus.daangnClone.handler.exception.CustomApiException;
+import com.t1dmlgus.daangnClone.user.domain.Role;
 import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.domain.UserRepository;
 import com.t1dmlgus.daangnClone.user.ui.dto.JoinRequestDto;
@@ -33,10 +34,16 @@ public class UserServiceImpl implements UserService{
         bcryptPw(user);
 
         // 3. 권한 처리
+        setPermission(user);
+
         // 4. 영속화
         User joinUser = userRepository.save(user);
 
         return new ResponseDto<>("회원가입이 완료되었습니다.", joinUser.getId());
+    }
+
+    protected void setPermission(User user) {
+       user.setPermission(Role.ROLE_USER);
     }
 
     protected void duplicateUser(User user){

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserServiceImpl.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/application/UserServiceImpl.java
@@ -18,17 +18,35 @@ public class UserServiceImpl implements UserService{
 
     private final UserRepository userRepository;
 
+    @Override
     @Transactional
     public ResponseDto<?> join(JoinRequestDto joinRequestDto) {
 
         User user = joinRequestDto.toEntity();
+
+        // 1. 중복확인(이메일)
+        duplicateUser(user);
+
+        // 2. 암호화(패스웨드)
+        // 3. 권한 처리
+        // 4. 영속화
         User joinUser = userRepository.save(user);
 
         return new ResponseDto<>("회원가입이 완료되었습니다.", joinUser.getId());
     }
 
+    // 아이디 중복확인
+    protected void duplicateUser(User user){
+
+        boolean existsUsername = userRepository.existsByEmail(user.getEmail());
+        if(existsUsername){
+            throw new CustomApiException("현재 사용중인 이메일입니다.");
+        }
+    }
+
 
     @Override
+    @Transactional
     public ResponseDto<?> enquiry(Long userId) {
 
         User enquiryUser = userRepository.findById(userId).orElseThrow(

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/Role.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/Role.java
@@ -1,8 +1,5 @@
 package com.t1dmlgus.daangnClone.user.domain;
 
-import javax.persistence.Enumerated;
-
-
 public enum Role {
 
     ROLE_USER,

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/User.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/User.java
@@ -46,4 +46,8 @@ public class User extends BaseTimeEntity {
         this.password = encode;
     }
 
+    // 권한 설정
+    public void setPermission(Role role) {
+        this.role = role;
+    }
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/User.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/User.java
@@ -41,8 +41,9 @@ public class User extends BaseTimeEntity {
         this.role = role;
     }
 
-
-
-
+    // 비밀번호 암호화
+    public void bcryptPw(String encode) {
+        this.password = encode;
+    }
 
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/UserRepository.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/UserRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    boolean existsByEmail(String email);
+
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/UserApiController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/UserApiController.java
@@ -6,7 +6,10 @@ import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
@@ -17,7 +20,7 @@ public class UserApiController {
 
 
     @PostMapping("/signup")
-    public ResponseEntity<?> join(@RequestBody JoinRequestDto joinRequestDto){
+    public ResponseEntity<?> join(@Valid @RequestBody JoinRequestDto joinRequestDto, BindingResult bindingResult){
 
         ResponseDto<?> joinUser = userService.join(joinRequestDto);
 

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/JoinRequestDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/JoinRequestDto.java
@@ -5,19 +5,28 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class JoinRequestDto {
 
+    @Email(message = "email 형식이 아닙니다.")
+    @NotBlank(message = "email을 적어주세요")
     private String email;
 
+    @NotBlank(message = "패스워드를 입력해주세요.")
     private String password;
 
+    @NotBlank(message = "이름을 적어주세요")
     private String name;
 
     private String phone;
 
+    @NotBlank(message = "닉네임을 적어주세요")
     private String nickName;
 
     public User toEntity(){

--- a/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
@@ -38,10 +38,8 @@ class UserServiceImplUnitTest {
     public void joinTest() throws Exception{
         //given
 
-        JoinRequestDto joinRequestDto = new JoinRequestDto("dmlgusgngl@gmail.com",
-                "1234", "이의현", "2232-1234", "t1dmlgus");
+        JoinRequestDto joinRequestDto = new JoinRequestDto("dmlgusgngl@gmail.com", "1234", "이의현", "2232-1234", "t1dmlgus");
         User user = joinRequestDto.toEntity();
-
         doReturn(user).when(userRepository).save(any(User.class));
 
         //when
@@ -50,6 +48,28 @@ class UserServiceImplUnitTest {
         //then
         assertThat(join.getMessage()).isEqualTo("회원가입이 완료되었습니다.");
     }
+
+    @DisplayName("닉네임 중복검사 테스트")
+    @Test
+    public void duplicateUsernameTest() throws Exception {
+        //given
+        User testUser1 = User.builder()
+                .email("테스트1@gmail.com")
+                .build();
+        User testUser2 = User.builder()
+                .email("테스트1@gmail.com")
+                .build();
+
+        when(userRepository.existsByEmail(testUser1.getEmail())).thenReturn(true);
+        //when
+
+        //then
+        assertThatThrownBy(() -> userServiceImpl.duplicateUser(testUser2))
+                .isInstanceOf(CustomApiException.class)
+                .hasMessage("현재 사용중인 이메일입니다.");
+    }
+
+
 
     @DisplayName("서비스 - 회원조회 테스트")
     @Test

--- a/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -31,7 +33,8 @@ class UserServiceImplUnitTest {
     private UserServiceImpl userServiceImpl;
     @Mock
     private UserRepository userRepository;
-    
+    @Spy
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
     
     @DisplayName("서비스 - 회원가입 테스트")
     @Test
@@ -67,6 +70,22 @@ class UserServiceImplUnitTest {
         assertThatThrownBy(() -> userServiceImpl.duplicateUser(testUser2))
                 .isInstanceOf(CustomApiException.class)
                 .hasMessage("현재 사용중인 이메일입니다.");
+    }
+
+    @DisplayName("비밀번호 암호화 테스트")
+    @Test
+    public void bcryptPwTest() throws Exception {
+        //given
+        User testUser = User.builder()
+                .email("테스트1")
+                .password("1234")
+                .build();
+
+        //when
+        userServiceImpl.bcryptPw(testUser);
+        //then
+        assertThat(testUser.getPassword()).isNotEqualTo("1234");
+
     }
 
 

--- a/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
@@ -52,7 +52,7 @@ class UserServiceImplUnitTest {
         assertThat(join.getMessage()).isEqualTo("회원가입이 완료되었습니다.");
     }
 
-    @DisplayName("닉네임 중복검사 테스트")
+    @DisplayName("서비스- 이메일 중복확인 테스트")
     @Test
     public void duplicateUsernameTest() throws Exception {
         //given
@@ -72,7 +72,7 @@ class UserServiceImplUnitTest {
                 .hasMessage("현재 사용중인 이메일입니다.");
     }
 
-    @DisplayName("비밀번호 암호화 테스트")
+    @DisplayName("서비스 - 비밀번호 암호화 테스트")
     @Test
     public void bcryptPwTest() throws Exception {
         //given
@@ -88,7 +88,7 @@ class UserServiceImplUnitTest {
 
     }
 
-    @DisplayName("권한 설정 테스트")
+    @DisplayName("서비스 - 권한 설정 테스트")
     @Test
     public void setPermissionTest() throws Exception{
         //given

--- a/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/user/application/UserServiceImplUnitTest.java
@@ -88,6 +88,21 @@ class UserServiceImplUnitTest {
 
     }
 
+    @DisplayName("권한 설정 테스트")
+    @Test
+    public void setPermissionTest() throws Exception{
+        //given
+        User testUser = User.builder()
+                .email("테스트1")
+                .password("1234")
+                .build();
+
+        //when
+        userServiceImpl.setPermission(testUser);
+        
+        //then
+        assertThat(testUser.getRole()).isEqualTo(Role.ROLE_USER);
+    }
 
 
     @DisplayName("서비스 - 회원조회 테스트")


### PR DESCRIPTION
### 이슈번호
resolved: #8

### 개요

회원가입 리펙토링
- 회원가입 시 유효성 검사
- 아이디 중복확인
- 비밀번호 암호화
- 권한 설정

### 작업 내용

UserServiceImpl.java

- duplicateUser(유저 중복확인) 메서드 추가, UserRepository.existsByEmail로 이메일 중복확인
- CustomApiException 해당 메소드 예외처리
- bCryptPasswordEncoder 로 회원가입 시 요청한 패스워드를 암호화하여 User 비밀번호 암호화(비즈니스 로직) 호출
- ROLE_USER 권한 추가
- @Transactional으로 중복확인, 암호화, 권한 처리 기능 후 영속화 등, 일련의 작업들을 묶어서 하나의 단위로 처리


build.gradle
- SpringSecurity, Validation 의존성 추가

SecurityConfig
- BCryptPasswordEncoder 빈 등록
- 회원가입 요청 시 권한 설정(permitAll)

JoinRequestDto.java

- 유효성 검사가 필요한 필드에 validation 어노테이션 추가

ValidationAdvice.java

- AOP를 사용하여 유효성 검사 구현
- @Around 어노테이션을 이용하여, 어드바이스가 타겟 메소드를 감싸서 타겟 메소드 호출전과 후에 어드바이스 기능을 수행
- JoinPoint를 상속받은 ProceedingJoinPoint로 회원가입 요청 실행시점에 메소드 호출하여 요청 데이터들에 대해 유효성검사 
  - 유효성 검사 실패 시 CustomValidationException 예외 생성
  - 예외 없을 시 조인포인트로 리턴

UserApiController.java

- @Valid 요청된 데이터에 유효성 검사 후 BindingResult에 담음


### 테스트

- [x] UserServiceImplUnitTest.java
- [x] UserApiControllerUnitTest.java


### 주의사항

비밀번호 암호화 구현 시, @Spy BCryptPasswordEncoder  사용, 
@Spy 등, 테스트 기반 어노테이션의 정리 필요


