### PR TITLE
feat: 상품 등록 기능 구현(ISSUE-15)

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-aws-context', version: '2.2.2.RELEASE'
+
 	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.6'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductService.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductService.java
@@ -8,5 +8,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ProductService {
 
     // 상품 등록
-    ResponseDto<?> register(ProductRequestDto productRequestDto, MultipartFile multipartFile, Long userId);
+    ResponseDto<?> registerProduct(ProductRequestDto productRequestDto, MultipartFile multipartFile);
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImpl.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImpl.java
@@ -1,0 +1,42 @@
+package com.t1dmlgus.daangnClone.product.application;
+
+import com.t1dmlgus.daangnClone.product.domain.Product;
+import com.t1dmlgus.daangnClone.product.domain.ProductRepository;
+import com.t1dmlgus.daangnClone.product.ui.ProductApiController;
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@RequiredArgsConstructor
+@Service
+public class ProductServiceImpl implements ProductService{
+
+    private final ProductRepository productRepository;
+    private final S3Service s3Service;
+
+    Logger logger = LoggerFactory.getLogger(ProductApiController.class);
+
+    @Transactional
+    @Override
+    public ResponseDto<?> registerProduct(ProductRequestDto productRequestDto, MultipartFile multipartFile) {
+
+        Product product = productRequestDto.toEntity();
+
+        // 1. 영속화
+        Product saveProduct = productRepository.save(product);
+        logger.info("saveProduct, {}", saveProduct);
+
+        // 2. 이미지 업로드
+        s3Service.upload(multipartFile, saveProduct);
+
+        return new ResponseDto<>("상품이 등록되었습니다.", saveProduct.getId());
+    }
+
+
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/S3Service.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/S3Service.java
@@ -1,0 +1,114 @@
+package com.t1dmlgus.daangnClone.product.application;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.t1dmlgus.daangnClone.handler.exception.CustomApiException;
+import com.t1dmlgus.daangnClone.product.domain.Image;
+import com.t1dmlgus.daangnClone.product.domain.ImageRepository;
+import com.t1dmlgus.daangnClone.product.domain.Product;
+import com.t1dmlgus.daangnClone.product.ui.ProductApiController;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.annotation.PostConstruct;
+import java.util.UUID;
+
+
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+
+    Logger logger = LoggerFactory.getLogger(S3Service.class);
+
+    //public static final String CLOUD_FRONT_DOMAIN_NAME="d3r3itann8ixvx.cloudfront.net";
+
+    private final ImageRepository imageRepository;
+    private AmazonS3 s3Client;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+
+    @PostConstruct
+    public void setS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
+
+        s3Client = AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(this.region)
+                .build();
+    }
+
+
+    public void upload(MultipartFile multipartFile, Product product){
+
+        // 파일명
+        String fileName = createFileName(multipartFile);
+        logger.info("fileName, {}", fileName);
+
+        // 업로드
+        uploadImages(multipartFile, fileName);
+
+        // 영속화
+        saveImages(fileName, product);
+    }
+
+    // 이미지 업로드(s3)
+    protected void uploadImages(MultipartFile multipartFile, String fileName) {
+        try {
+            ObjectMetadata objMeta = new ObjectMetadata();
+            byte[] bytes = IOUtils.toByteArray(multipartFile.getInputStream());
+            objMeta.setContentLength(bytes.length);
+
+            s3Client.putObject(new PutObjectRequest(bucket, fileName, multipartFile.getInputStream(), objMeta)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+
+
+        } catch (Exception e) {
+            //e.printStackTrace();
+            throw new CustomApiException("s3 이미지 업로드에 실패하였습니다.");
+        }
+    }
+
+    // 이미지 영속화
+    protected Long saveImages(String fileName, Product product) {
+        Image saveImage = imageRepository.save(new Image(fileName, product));
+        return saveImage.getId();
+    }
+
+    // 파일명
+    protected String createFileName(MultipartFile multipartFile) {
+        UUID uuid = UUID.randomUUID();
+        String originalFilename = multipartFile.getOriginalFilename();
+
+        return uuid +"_"+ originalFilename;
+    }
+    
+    // 유효성 검사
+    protected void validationFile(MultipartFile multipartFile) {
+        if (multipartFile == null) {
+            throw new CustomApiException("이미지가 첨부되지 않았습니다.");
+        }
+    }
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/Product.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/Product.java
@@ -1,6 +1,7 @@
 package com.t1dmlgus.daangnClone.product.domain;
 
 import com.t1dmlgus.daangnClone.BaseTimeEntity;
+import com.t1dmlgus.daangnClone.user.domain.User;
 import lombok.*;
 
 import javax.persistence.*;
@@ -30,6 +31,9 @@ public class Product extends BaseTimeEntity {
 
     // 거래 상태 -> enum
     private String status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
 
 
     @Builder

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductApiController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductApiController.java
@@ -1,15 +1,37 @@
 package com.t1dmlgus.daangnClone.product.ui;
 
+import com.t1dmlgus.daangnClone.product.application.ProductService;
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequestMapping("/api/product")
 @RequiredArgsConstructor
 @RestController
 public class ProductApiController {
 
-    
+    private final ProductService productService;
+
+    Logger logger = LoggerFactory.getLogger(ProductApiController.class);
+
+    @PostMapping()
+    public ResponseEntity<?> register(ProductRequestDto productRequestDto, @RequestPart(value = "file") MultipartFile file) {   // 유저 추가(세션)
+
+        logger.info("productRequestDto, {}", productRequestDto);
+        logger.info("multipartFile-file, {}", file);
+
+        Long userId = 1L;
+        ResponseDto<?> registerDto = productService.registerProduct(productRequestDto, file);
+
+        return new ResponseEntity<>(registerDto, HttpStatus.CREATED);
+
+    }
 
 
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/product/ProductRequestDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/product/ProductRequestDto.java
@@ -1,0 +1,38 @@
+package com.t1dmlgus.daangnClone.user.ui.dto.product;
+
+import com.t1dmlgus.daangnClone.product.domain.Category;
+import com.t1dmlgus.daangnClone.product.domain.Product;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ProductRequestDto {
+
+    @NotBlank(message = "제목을 입력해주세요")
+    private String title;
+
+    //@NotBlank(message = "카테고리를 골라주세요")
+    private Category category;
+
+    @NotBlank(message = "가격을 입력해주세요")
+    private int price;
+
+    @NotBlank(message = "본문을 입력해주세요")
+    private String caption;
+
+
+    public Product toEntity(){
+
+        return Product.builder()
+                .title(title)
+                .price(price)
+                .caption(caption)
+                .build();
+    }
+}

--- a/back/src/test/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImplTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImplTest.java
@@ -1,0 +1,56 @@
+package com.t1dmlgus.daangnClone.product.application;
+
+import com.t1dmlgus.daangnClone.product.domain.Product;
+import com.t1dmlgus.daangnClone.product.domain.ProductRepository;
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class ProductServiceImplTest {
+
+
+    @InjectMocks
+    private ProductServiceImpl productServiceImpl;
+
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private S3Service s3service;
+    
+    @DisplayName("서비스 - 상품 등록 테스트")
+    @Test
+    public void registerTest() throws Exception{
+        //given
+
+        ProductRequestDto productRequestDto = new ProductRequestDto("상품명",null,100,"상품내용");
+        MockMultipartFile file = new MockMultipartFile("파일명", "파일명.jpeg", "image/jpeg", "파일12".getBytes());
+
+        doReturn(new Product()).when(productRepository).save(any());
+        doNothing().when(s3service).upload(any(),any());
+
+        //when
+        ResponseDto<?> responseDto = productServiceImpl.registerProduct(productRequestDto, file);
+
+        //then
+        assertThat(responseDto.getMessage()).isEqualTo("상품이 등록되었습니다.");
+        
+        
+    }
+    
+    
+}

--- a/back/src/test/java/com/t1dmlgus/daangnClone/product/application/S3ServiceUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/product/application/S3ServiceUnitTest.java
@@ -1,0 +1,84 @@
+package com.t1dmlgus.daangnClone.product.application;
+
+import com.t1dmlgus.daangnClone.handler.exception.CustomApiException;
+import com.t1dmlgus.daangnClone.product.domain.Image;
+import com.t1dmlgus.daangnClone.product.domain.ImageRepository;
+import com.t1dmlgus.daangnClone.product.domain.Product;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class S3ServiceUnitTest {
+
+    Logger logger = LoggerFactory.getLogger(S3ServiceUnitTest.class);
+
+    @InjectMocks
+    private S3Service s3Service;
+
+    @Mock
+    private ImageRepository imageRepository;
+
+    @DisplayName("서비스 - 이미지 파일명 생성 테스트")
+    @Test
+    public void createFileName() throws Exception{
+        //given
+        MockMultipartFile file = new MockMultipartFile("파일명", "파일명.jpeg", "image/jpeg", "파일12".getBytes());
+        //when
+        String fileName = s3Service.createFileName(file);
+        logger.info("fileName, {}", fileName);
+        
+        //then
+        assertThat(fileName).contains("파일명.jpeg");
+    }    
+
+    @DisplayName("서비스 - 이미지 업로드(실패) 테스트")
+    @Test
+    public void uploadImageTest() throws Exception{
+        //given
+        MockMultipartFile file = new MockMultipartFile("파일명", "파일명.jpeg", "image/jpeg", "파일12".getBytes());
+        String fileName = "uuid_파일명";
+        //when
+
+        //then
+        assertThatThrownBy(() -> s3Service.uploadImages(file, fileName))
+                .isInstanceOf(Exception.class)
+                .hasMessage("s3 이미지 업로드에 실패하였습니다.");
+
+    }
+
+    @DisplayName("서비스 - 이미지 저장 테스트")
+    @Test
+    public void saveImageTest() throws Exception{
+        //given
+        String fileName = "uuid_파일명";
+        Product product = new Product();
+        given(imageRepository.save(any())).willReturn(new Image(1L, fileName, product));
+
+        //when
+        Long saveImageId = s3Service.saveImages(fileName, product);
+
+        //then
+        assertThat(saveImageId).isEqualTo(1L);
+
+    }
+}
+
+

--- a/back/src/test/java/com/t1dmlgus/daangnClone/product/ui/ProductApiControllerTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/product/ui/ProductApiControllerTest.java
@@ -1,0 +1,80 @@
+package com.t1dmlgus.daangnClone.product.ui;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.t1dmlgus.daangnClone.product.application.ProductService;
+import com.t1dmlgus.daangnClone.user.ui.UserApiController;
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockPart;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(value = ProductApiController.class)
+class ProductApiControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    private ProductService productService;
+
+    @BeforeEach
+    void setup(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .build();
+        
+    }
+    
+    @DisplayName("컨트롤러 - 상품등록 테스트")
+    @Test
+    public void registerProductTest() throws Exception{
+        //given
+        MockMultipartFile file2 = new MockMultipartFile("file", "파일명.jpeg", "image/jpeg", "파일12".getBytes());
+        doReturn(new ResponseDto<>("상품이 등록되었습니다.", 16L))
+                .when(productService).registerProduct(any(), any());
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                multipart("/api/product")
+                        .file(file2)
+                        .param("title", "상품명")
+                        .param("price", "100")
+                        .param("caption", "본문")
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON_UTF8)
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isCreated())
+                .andDo(print());
+    }
+
+    
+
+
+}


### PR DESCRIPTION
### 이슈번호
resolved: #15 

### 개요

상품 등록 기능 구현

### 작업 내용

build.gradle
- s3에 이미지를 업로드 하기 위해 AWS. springframework.cloud 의존성 추가

ProductServiceImpl.java

- ProductServcie를 상속받아 상품등록 메소드를 구현
- 상품등록으로 받은 데이터를 먼저 영속화 한후, AmazonS3ClientBuilde로 생성한 S3Service로 이미지 업로드를 실행
- ResponseDto를 통해 상품등록 메시지와 영속화된 상품 id를 반환

S3Service.java

- @Value 어노테이션을 통해 yml에 작성된 S3 버킷의 정보의 값을 지정
- 이미지 업로드 메소드는 파일명 변환, 이미지 업로드(S3), 영속화 3단계로 구성


ProductApiController.java

- FormData를 통해 url 호출 시, productRequestDto와 Multipart 형식의 이미지 파일을 바인딩하여 인수로 받음
- ProductService 클래스 타입의 registerProduct() 실행하여 상품등록 서비스 실행
- multipart/form-data

![image](https://user-images.githubusercontent.com/59961350/149688337-dc2110c1-aa13-43fe-bb5d-dc66f8910dba.png)



### 테스트

- [x] ProductServiceImplTest.java
- [x] S3ServiceUnitTest.java
- [x] ProductApiController.java

### 주의사항

- 이미지 업로드는 시간 관계상 단일만 기능 구현, 추후 다중 이미지 업로드 리펙토링 필요
- 상품 등록 시, 로그인이 구현되면 유저(세션) 등록 기능 추가

