### PR TITLE
[BE] 로그인 구현[ISSUE-7]

### DIFF
--- a/back/src/main/java/com/t1dmlgus/daangnClone/auth/application/PrincipalDetailsService.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/auth/application/PrincipalDetailsService.java
@@ -1,0 +1,29 @@
+package com.t1dmlgus.daangnClone.auth.application;
+
+import com.t1dmlgus.daangnClone.auth.domain.PrincipalDetails;
+import com.t1dmlgus.daangnClone.user.domain.User;
+import com.t1dmlgus.daangnClone.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PrincipalDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        User byEmail = userRepository.findByEmail(username);
+
+        if (byEmail != null) {
+            return new PrincipalDetails(byEmail);
+        }
+        return null;
+    }
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/auth/domain/PrincipalDetails.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/auth/domain/PrincipalDetails.java
@@ -1,0 +1,66 @@
+package com.t1dmlgus.daangnClone.auth.domain;
+
+import com.t1dmlgus.daangnClone.user.domain.User;
+import lombok.Data;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+@Data
+public class PrincipalDetails implements UserDetails {
+
+    private User user;
+    private Map<String, Object> attribute;
+
+    public PrincipalDetails(User user) {
+        this.user = user;
+    }
+
+    public PrincipalDetails(User user, Map<String, Object> attribute) {
+        this.user = user;
+        this.attribute = attribute;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(() -> user.getRole().toString());
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/auth/ui/AuthController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/auth/ui/AuthController.java
@@ -1,0 +1,19 @@
+package com.t1dmlgus.daangnClone.auth.ui;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    @GetMapping("/auth")
+    public Authentication auth(){
+
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/config/SecurityConfig.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/config/SecurityConfig.java
@@ -1,7 +1,10 @@
 package com.t1dmlgus.daangnClone.config;
 
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -19,15 +22,21 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
         http.csrf().disable();
         http.authorizeRequests()
-                .antMatchers("/api/user/signup").permitAll()
+                .antMatchers("/", "/api/user/signup").permitAll()
+                .antMatchers("/api/product/**", "/user/**").authenticated()
                 .and()
                 .formLogin()
+                .loginProcessingUrl("/api/signin")
                 .defaultSuccessUrl("/", false);
 
-
-
-
-
-
     }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring()
+                .requestMatchers(
+                        PathRequest.toStaticResources().atCommonLocations()
+                );
+    }
+
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductService.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductService.java
@@ -1,5 +1,6 @@
 package com.t1dmlgus.daangnClone.product.application;
 
+import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
 import org.springframework.web.multipart.MultipartFile;
@@ -8,5 +9,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ProductService {
 
     // 상품 등록
-    ResponseDto<?> registerProduct(ProductRequestDto productRequestDto, MultipartFile multipartFile);
+    ResponseDto<?> registerProduct(ProductRequestDto productRequestDto, MultipartFile multipartFile, User user);
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImpl.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImpl.java
@@ -3,6 +3,7 @@ package com.t1dmlgus.daangnClone.product.application;
 import com.t1dmlgus.daangnClone.product.domain.Product;
 import com.t1dmlgus.daangnClone.product.domain.ProductRepository;
 import com.t1dmlgus.daangnClone.product.ui.ProductApiController;
+import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
 import lombok.RequiredArgsConstructor;
@@ -24,9 +25,9 @@ public class ProductServiceImpl implements ProductService{
 
     @Transactional
     @Override
-    public ResponseDto<?> registerProduct(ProductRequestDto productRequestDto, MultipartFile multipartFile) {
+    public ResponseDto<?> registerProduct(ProductRequestDto productRequestDto, MultipartFile multipartFile, User user) {
 
-        Product product = productRequestDto.toEntity();
+        Product product = productRequestDto.toEntity(user);
 
         // 1. 영속화
         Product saveProduct = productRepository.save(product);

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/Product.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/Product.java
@@ -37,9 +37,10 @@ public class Product extends BaseTimeEntity {
 
 
     @Builder
-    public Product(String title, int price, String caption) {
+    public Product(String title, int price, String caption, User user) {
         this.title = title;
         this.price = price;
         this.caption = caption;
+        this.user = user;
     }
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductApiController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductApiController.java
@@ -1,5 +1,6 @@
 package com.t1dmlgus.daangnClone.product.ui;
 
+import com.t1dmlgus.daangnClone.auth.domain.PrincipalDetails;
 import com.t1dmlgus.daangnClone.product.application.ProductService;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
@@ -8,6 +9,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,14 +24,15 @@ public class ProductApiController {
 
     Logger logger = LoggerFactory.getLogger(ProductApiController.class);
 
-    @PostMapping()
-    public ResponseEntity<?> register(ProductRequestDto productRequestDto, @RequestPart(value = "file") MultipartFile file) {   // 유저 추가(세션)
+    @PostMapping("/register")
+    public ResponseEntity<?> register(ProductRequestDto productRequestDto, @RequestPart(value = "file") MultipartFile file, @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         logger.info("productRequestDto, {}", productRequestDto);
         logger.info("multipartFile-file, {}", file);
 
-        Long userId = 1L;
-        ResponseDto<?> registerDto = productService.registerProduct(productRequestDto, file);
+        ResponseDto<?> registerDto = productService.registerProduct(productRequestDto, file, principalDetails.getUser());
+
+        logger.info(SecurityContextHolder.getContext().toString());
 
         return new ResponseEntity<>(registerDto, HttpStatus.CREATED);
 

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/User.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/User.java
@@ -1,24 +1,27 @@
 package com.t1dmlgus.daangnClone.user.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.t1dmlgus.daangnClone.BaseTimeEntity;
 import lombok.*;
 
 import javax.persistence.*;
 
 
-@Entity
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
+@Entity
 public class User extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String email;
 
+    @JsonIgnore
     private String password;
 
     private String name;

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/UserRepository.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/domain/UserRepository.java
@@ -6,4 +6,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
+    User findByEmail(String email);
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/product/ProductRequestDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/user/ui/dto/product/ProductRequestDto.java
@@ -2,6 +2,7 @@ package com.t1dmlgus.daangnClone.user.ui.dto.product;
 
 import com.t1dmlgus.daangnClone.product.domain.Category;
 import com.t1dmlgus.daangnClone.product.domain.Product;
+import com.t1dmlgus.daangnClone.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -27,12 +28,13 @@ public class ProductRequestDto {
     private String caption;
 
 
-    public Product toEntity(){
+    public Product toEntity(User user){
 
         return Product.builder()
                 .title(title)
                 .price(price)
                 .caption(caption)
+                .user(user)
                 .build();
     }
 }

--- a/back/src/test/java/com/t1dmlgus/daangnClone/auth/WithMockCustomUser.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/auth/WithMockCustomUser.java
@@ -1,0 +1,17 @@
+package com.t1dmlgus.daangnClone.auth;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory =  WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+    String username() default "testID";
+
+    String name() default "이의현";
+
+}

--- a/back/src/test/java/com/t1dmlgus/daangnClone/auth/WithMockCustomUserSecurityContextFactory.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/auth/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,29 @@
+package com.t1dmlgus.daangnClone.auth;
+
+import com.t1dmlgus.daangnClone.auth.domain.PrincipalDetails;
+import com.t1dmlgus.daangnClone.user.domain.Role;
+import com.t1dmlgus.daangnClone.user.domain.User;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser customUser) {
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        User testUser = new User(1L,"test@gmail.com","1234","이의현","1234-1234","t1dmlgus", Role.ROLE_USER);
+
+        PrincipalDetails principal = new PrincipalDetails(testUser);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities());
+        context.setAuthentication(authentication);
+
+
+        return context;
+    }
+}

--- a/back/src/test/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImplTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImplTest.java
@@ -2,6 +2,7 @@ package com.t1dmlgus.daangnClone.product.application;
 
 import com.t1dmlgus.daangnClone.product.domain.Product;
 import com.t1dmlgus.daangnClone.product.domain.ProductRepository;
+import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
 import org.junit.jupiter.api.DisplayName;
@@ -44,7 +45,7 @@ class ProductServiceImplTest {
         doNothing().when(s3service).upload(any(),any());
 
         //when
-        ResponseDto<?> responseDto = productServiceImpl.registerProduct(productRequestDto, file);
+        ResponseDto<?> responseDto = productServiceImpl.registerProduct(productRequestDto, file, new User());
 
         //then
         assertThat(responseDto.getMessage()).isEqualTo("상품이 등록되었습니다.");

--- a/back/src/test/java/com/t1dmlgus/daangnClone/product/ui/ProductApiControllerTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/product/ui/ProductApiControllerTest.java
@@ -1,6 +1,8 @@
 package com.t1dmlgus.daangnClone.product.ui;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.t1dmlgus.daangnClone.auth.WithMockCustomUser;
+import com.t1dmlgus.daangnClone.auth.domain.PrincipalDetails;
 import com.t1dmlgus.daangnClone.product.application.ProductService;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +16,9 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -47,19 +52,23 @@ class ProductApiControllerTest {
                 .apply(documentationConfiguration(restDocumentation))
                 .build();
 
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
     }
+
     
     @DisplayName("컨트롤러 - 상품등록 테스트")
     @Test
+    @WithMockCustomUser
     public void registerProductTest() throws Exception{
         //given
         MockMultipartFile file2 = new MockMultipartFile("file", "파일명.jpeg", "image/jpeg", "이미지파일".getBytes());
         doReturn(new ResponseDto<>("상품이 등록되었습니다.", 16L))
-                .when(productService).registerProduct(any(), any());
+                .when(productService).registerProduct(any(), any(), any());
 
         //when
         ResultActions resultActions = mockMvc.perform(
-                multipart("/api/product")
+                multipart("/api/product/register")
                         .file(file2)
                         .param("title", "상품명")
                         .param("price", "100")


### PR DESCRIPTION
### 이슈번호
resolved: #7 

### 개요

로그인 구현

### 작업 내용

securityConfig.java

- WebSecurityConfigurerAdapter를 상속받아, configure(HttpSecurity) 로 설정
- 리소스(URL) 접근 권한 설정(유저, 상품)
- 폼 로그인(formLogin) 기반으로 로그인 처리

PrincipalDetails

- UserDetails 를 상속받아, 인증 권한 설정

PrincipalDetailsService.java

- 로그인 요청 시, UserDeatailsService 타입의 loadUserByUsername 호출
- UsernamePasswordAuthenticationFilter 인증로직을 거쳐 username이 DB에 있으면, PrincipalDetails 객체 생성

WithMockCustomUser.java

- WithSecurityContextFactory를 상속받아, WithMockCustomUserSecurityContextFactory 클래스 생성
- UsernamePasswordAuthenticationToken 생성하여, SecurityContext 에 담음
- 인증된 테스트 시, @WithMockCustomUser 어노테이션을 사용하여 테스트 진행(인증된)

### 테스트 리펙토링

- [x] ProductServiceImplTest.java
- [x] ProductApiControllerTest.java


### 주의사항

- 로그인 시 loadUserByUsername 호출 될때, 넘어오는 인수값은 username으로 지정되어 있다. (필요시 커스텀해서 사용가능)


