### PR TITLE
[BE] 상품조회 API 구현 및 상품 페이지 렌더링[ISSUE-21]

### DIFF
--- a/back/src/main/java/com/t1dmlgus/daangnClone/auth/ui/AuthController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/auth/ui/AuthController.java
@@ -1,13 +1,10 @@
 package com.t1dmlgus.daangnClone.auth.ui;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
 
 @Controller
 public class AuthController {

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductService.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductService.java
@@ -1,13 +1,25 @@
 package com.t1dmlgus.daangnClone.product.application;
 
+import com.t1dmlgus.daangnClone.product.ui.dto.InquiryProductTopFourResponseDto;
 import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
-import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
+import com.t1dmlgus.daangnClone.product.ui.dto.ProductRequestDto;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 
 public interface ProductService {
 
     // 상품 등록
     ResponseDto<?> registerProduct(ProductRequestDto productRequestDto, MultipartFile multipartFile, User user);
+
+    // 상품 조회
+    ResponseDto<?> inquiryProduct(Long productId);
+
+    // 상품 수정
+
+    // 상품 삭제
+
+
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductService.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductService.java
@@ -1,12 +1,9 @@
 package com.t1dmlgus.daangnClone.product.application;
 
-import com.t1dmlgus.daangnClone.product.ui.dto.InquiryProductTopFourResponseDto;
+import com.t1dmlgus.daangnClone.product.ui.dto.ProductRequestDto;
 import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
-import com.t1dmlgus.daangnClone.product.ui.dto.ProductRequestDto;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 
 public interface ProductService {

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImpl.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImpl.java
@@ -1,15 +1,14 @@
 package com.t1dmlgus.daangnClone.product.application;
 
 import com.t1dmlgus.daangnClone.handler.exception.CustomApiException;
-import com.t1dmlgus.daangnClone.product.domain.Image;
 import com.t1dmlgus.daangnClone.product.domain.Product;
 import com.t1dmlgus.daangnClone.product.domain.ProductRepository;
 import com.t1dmlgus.daangnClone.product.ui.ProductApiController;
 import com.t1dmlgus.daangnClone.product.ui.dto.InquiryProductResponseDto;
 import com.t1dmlgus.daangnClone.product.ui.dto.InquiryProductTopFourResponseDto;
+import com.t1dmlgus.daangnClone.product.ui.dto.ProductRequestDto;
 import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
-import com.t1dmlgus.daangnClone.product.ui.dto.ProductRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +61,7 @@ public class ProductServiceImpl implements ProductService{
     }
 
     // 유저 판매 상폼 조회(top4)
-    public List<InquiryProductTopFourResponseDto> inquiryTopFourProduct(Long userId) {
+    protected List<InquiryProductTopFourResponseDto> inquiryTopFourProduct(Long userId) {
 
         List<InquiryProductTopFourResponseDto> t4Product = new ArrayList<>();
         List<Product> products = productRepository.inquiryProductTopFourByUser(userId);

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/S3Service.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/S3Service.java
@@ -13,8 +13,6 @@ import com.t1dmlgus.daangnClone.handler.exception.CustomApiException;
 import com.t1dmlgus.daangnClone.product.domain.Image;
 import com.t1dmlgus.daangnClone.product.domain.ImageRepository;
 import com.t1dmlgus.daangnClone.product.domain.Product;
-import com.t1dmlgus.daangnClone.product.ui.ProductApiController;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/S3Service.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/S3Service.java
@@ -23,7 +23,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.annotation.PostConstruct;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 
 @RequiredArgsConstructor
@@ -32,7 +34,7 @@ public class S3Service {
 
     Logger logger = LoggerFactory.getLogger(S3Service.class);
 
-    //public static final String CLOUD_FRONT_DOMAIN_NAME="d3r3itann8ixvx.cloudfront.net";
+    public static final String CLOUD_FRONT_DOMAIN_NAME="dhtabz8gaqtjf.cloudfront.net/";
 
     private final ImageRepository imageRepository;
     private AmazonS3 s3Client;
@@ -66,10 +68,8 @@ public class S3Service {
         // 파일명
         String fileName = createFileName(multipartFile);
         logger.info("fileName, {}", fileName);
-
         // 업로드
         uploadImages(multipartFile, fileName);
-
         // 영속화
         saveImages(fileName, product);
     }
@@ -93,7 +93,8 @@ public class S3Service {
 
     // 이미지 영속화
     protected Long saveImages(String fileName, Product product) {
-        Image saveImage = imageRepository.save(new Image(fileName, product));
+
+        Image saveImage = imageRepository.save(new Image("https://" + CLOUD_FRONT_DOMAIN_NAME + fileName, product));
         return saveImage.getId();
     }
 
@@ -110,5 +111,15 @@ public class S3Service {
         if (multipartFile == null) {
             throw new CustomApiException("이미지가 첨부되지 않았습니다.");
         }
+    }
+
+
+    // 상품 이미지 조회
+    public List<String> inquiryProductImage(Long productId) {
+
+        List<String> ProductImages = imageRepository.findAllByProductId(productId)
+                .stream().map(Image::getFileName).collect(Collectors.toList());
+
+        return ProductImages;
     }
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/Image.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/Image.java
@@ -1,5 +1,6 @@
 package com.t1dmlgus.daangnClone.product.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.t1dmlgus.daangnClone.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
+@ToString(exclude = "product")
 public class Image extends BaseTimeEntity {
 
     @Id
@@ -23,6 +24,7 @@ public class Image extends BaseTimeEntity {
 
     private String fileName;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/ImageRepository.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/ImageRepository.java
@@ -2,5 +2,10 @@ package com.t1dmlgus.daangnClone.product.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    // 해당 상품 이미지 조회
+    List<Image> findAllByProductId(Long productId);
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/Product.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/Product.java
@@ -1,5 +1,6 @@
 package com.t1dmlgus.daangnClone.product.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.t1dmlgus.daangnClone.BaseTimeEntity;
 import com.t1dmlgus.daangnClone.user.domain.User;
 import lombok.*;
@@ -12,12 +13,11 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
+@ToString(exclude = "user")
 public class Product extends BaseTimeEntity {
 
     @Id
     @GeneratedValue
-    @Column(name = "Product_id")
     private Long id;
 
     private String title;
@@ -29,18 +29,20 @@ public class Product extends BaseTimeEntity {
 
     private String caption;
 
-    // 거래 상태 -> enum
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private SaleStatus status;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
 
     @Builder
-    public Product(String title, int price, String caption, User user) {
+    public Product(String title, int price, String caption,SaleStatus status, User user) {
         this.title = title;
         this.price = price;
         this.caption = caption;
+        this.status = status;
         this.user = user;
     }
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/ProductRepository.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/ProductRepository.java
@@ -1,6 +1,15 @@
 package com.t1dmlgus.daangnClone.product.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    @Query(value = "SELECT * FROM PRODUCT where user_Id = :userId\n" +
+            "order by created_date desc\n" +
+            "LIMIT 4", nativeQuery = true)
+    List<Product> inquiryProductTopFourByUser(@Param("userId") Long userId);
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/SaleStatus.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/SaleStatus.java
@@ -1,0 +1,6 @@
+package com.t1dmlgus.daangnClone.product.domain;
+
+public enum SaleStatus {
+    SALE,
+    SOLD_OUT
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductApiController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductApiController.java
@@ -2,14 +2,13 @@ package com.t1dmlgus.daangnClone.product.ui;
 
 import com.t1dmlgus.daangnClone.auth.domain.PrincipalDetails;
 import com.t1dmlgus.daangnClone.product.application.ProductService;
+import com.t1dmlgus.daangnClone.product.ui.dto.ProductRequestDto;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
-import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -24,19 +23,27 @@ public class ProductApiController {
 
     Logger logger = LoggerFactory.getLogger(ProductApiController.class);
 
+    // 상품 등록
     @PostMapping("/register")
     public ResponseEntity<?> register(ProductRequestDto productRequestDto, @RequestPart(value = "file") MultipartFile file, @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-        logger.info("productRequestDto, {}", productRequestDto);
-        logger.info("multipartFile-file, {}", file);
-
         ResponseDto<?> registerDto = productService.registerProduct(productRequestDto, file, principalDetails.getUser());
-
         logger.info(SecurityContextHolder.getContext().toString());
 
         return new ResponseEntity<>(registerDto, HttpStatus.CREATED);
+    }
+
+    // 상품 조회
+    @GetMapping("/{productId}")
+    public ResponseEntity<?> inquiryProduct(@PathVariable Long productId) {
+
+        ResponseDto<?> productDetailDto = productService.inquiryProduct(productId);
+
+        return new ResponseEntity<>(productDetailDto, HttpStatus.OK);
 
     }
 
 
+    
+    
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductController.java
@@ -1,0 +1,42 @@
+package com.t1dmlgus.daangnClone.product.ui;
+
+import com.t1dmlgus.daangnClone.product.application.ProductService;
+import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+
+@RequestMapping("/product")
+@RequiredArgsConstructor
+@Controller
+public class ProductController {
+
+    private final ProductService productService;
+
+    // 랜딩 페이지
+    @GetMapping("/randing")
+    public String randing(){
+        return "product/randing";
+    }
+
+    // 상품 상세 페이지
+    @GetMapping("/{productId}")
+    public String productDetail(@PathVariable Long productId, Model model){
+
+        ResponseDto<?> product = productService.inquiryProduct(productId);
+        model.addAttribute("product", product.getData());
+
+        return "product/product";
+    }
+
+    // 상품 모두보기 페이지
+    @GetMapping("/all")
+    public String allProduct(){
+        return "product/all";
+    }
+
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/dto/InquiryProductResponseDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/dto/InquiryProductResponseDto.java
@@ -1,0 +1,50 @@
+package com.t1dmlgus.daangnClone.product.ui.dto;
+
+import com.t1dmlgus.daangnClone.product.domain.Category;
+import com.t1dmlgus.daangnClone.product.domain.Product;
+import com.t1dmlgus.daangnClone.product.domain.SaleStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class InquiryProductResponseDto {
+
+    private String title;
+
+    private int price;
+
+    private Category category;
+
+    private LocalDateTime createTime;
+
+    private SaleStatus status;
+
+    private String nickName;
+
+    private String caption;
+
+    private List<String> images;
+
+    List<InquiryProductTopFourResponseDto> t4Prods;
+
+    public InquiryProductResponseDto(Product product, List<String> images, List<InquiryProductTopFourResponseDto> t4Prod) {
+
+        this.title = product.getTitle();
+        this.price = product.getPrice();
+        this.category = product.getCategory();
+        this.createTime = product.getCreatedDate();
+        this.status = product.getStatus();
+        this.nickName = product.getUser().getNickName();
+        this.caption = product.getCaption();
+        this.images = images;
+
+        this.t4Prods = t4Prod;
+
+    }
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/dto/InquiryProductTopFourResponseDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/dto/InquiryProductTopFourResponseDto.java
@@ -1,7 +1,6 @@
 package com.t1dmlgus.daangnClone.product.ui.dto;
 
 
-import com.t1dmlgus.daangnClone.product.domain.Image;
 import com.t1dmlgus.daangnClone.product.domain.Product;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/dto/InquiryProductTopFourResponseDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/dto/InquiryProductTopFourResponseDto.java
@@ -1,0 +1,26 @@
+package com.t1dmlgus.daangnClone.product.ui.dto;
+
+
+import com.t1dmlgus.daangnClone.product.domain.Image;
+import com.t1dmlgus.daangnClone.product.domain.Product;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class InquiryProductTopFourResponseDto {
+
+    private String title;
+    private int price;
+
+    private String coverImage;
+
+    public InquiryProductTopFourResponseDto(Product product, String coverImage) {
+        this.title = product.getTitle();
+        this.price = product.getPrice();
+        this.coverImage = coverImage;
+    }
+}

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/dto/ProductRequestDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/dto/ProductRequestDto.java
@@ -1,7 +1,8 @@
-package com.t1dmlgus.daangnClone.user.ui.dto.product;
+package com.t1dmlgus.daangnClone.product.ui.dto;
 
 import com.t1dmlgus.daangnClone.product.domain.Category;
 import com.t1dmlgus.daangnClone.product.domain.Product;
+import com.t1dmlgus.daangnClone.product.domain.SaleStatus;
 import com.t1dmlgus.daangnClone.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -34,6 +35,7 @@ public class ProductRequestDto {
                 .title(title)
                 .price(price)
                 .caption(caption)
+                .status(SaleStatus.SALE)
                 .user(user)
                 .build();
     }

--- a/back/src/main/resources/static/css/product.css
+++ b/back/src/main/resources/static/css/product.css
@@ -13,17 +13,17 @@
 #sec_02 .profile img{width: 40px;}
 #sec_02 .profile span{vertical-align: middle;line-height: 1;}
 #sec_02 .prod_desc{padding-bottom: 15px;}
-#sec_02 .prod_desc >div span{display: inline-block; width: 48%;}
+#sec_02 .prod_desc >div span{display: inline-block;}
 #sec_02 .prod_desc .cont{height: 80px;}
-
+#sec_02 .prod_desc .likes{display: inline-block;}
 
 #sec_03{margin:20px 30px;}
 #sec_03 .product_caption{padding-bottom: 15px;}
 #sec_03 .showall{float: right;}
 #sec_03 .products{}
-#sec_03 .products >a{display: inline-block; width: 46%; margin: 2% 1%;}
-#sec_03 .products >a img{border: 1px solid #000;box-sizing: border-box;}
-#sec_03 .products >a span{display: block; padding: 2px 0;}
+#sec_03 .products >div{display: inline-block; width: 46%; margin: 2% 1%;}
+#sec_03 .products >div img{border: 1px solid #000;box-sizing: border-box;}
+#sec_03 .products >div span{display: block; padding: 2px 0;}
 
 #sec_04{margin:20px 0px; padding: 10px 0; border-top: 1px solid #ccc;}
 #sec_04 .icon{width: 40%;display: inline-block;margin: 0 auto;}
@@ -31,6 +31,6 @@
 #sec_04 .commentbtn{display: inline-block; margin:0 10%; width: 25%;}
 
 #sec_04 .comment{width: 58%; display: inline-block;}
-#sec_04 .comment a{width: 41%; display: inline-block; padding:15px 5px; 
+#sec_04 .comment a{width: 41%; display: inline-block; padding:15px 5px;
     background-color: rgb(253, 137, 43);color: #fff;border-radius: 10px;font-size: 15px;
 text-align: center;}

--- a/back/src/main/resources/templates/product/product.html
+++ b/back/src/main/resources/templates/product/product.html
@@ -1,10 +1,15 @@
 <!doctype html>
-<html lang="ko">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+
+    <!-- 제이쿼리 -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- css -->
     <link rel="stylesheet" href="/css/default.css">
     <link rel="stylesheet" href="/css/product.css">
     <title>상품페이지</title>
@@ -16,8 +21,8 @@
             <img src="/img/home.png" alt="home">
         </a>
         <section id="sec_01">
-            <div class="product_img">
-                <img src="/img/product01.png" alt="상품이미지">
+            <div class="product_img" th:each="image : ${product.images}">
+                <img src="/img/product01.png" alt="f2" th:src="${image}">
             </div>
         </section>
         <!-- swiper -->
@@ -25,49 +30,45 @@
         <section id="sec_02">
             <div class="profile">
                 <img src="/img/profile.png" alt="프로필">
-                <span class="nickName">닉네임</span>
+                <span class="nickName" th:text="${product.nickName}">닉네임</span>
             </div>
             <div class="prod_desc">
                 <div>
-                    <span class="title">제목</span>
-                    <span class="price">가격</span>
+                    제목 <span class="title" th:text="${product.title}">제목</span>
                 </div>
                 <div>
-                    <span class="category">카테고리</span>
-                    <span class="uploadTime">게시시간</span>
+                    가격 <span class="price" th:text="${product.price}">가격</span>
                 </div>
-                <div class="cont">본문</div>
-                <div class="likes">관심 n</div>
+                <div>
+                   카테고리 <span class="category" th:text="${product.category}">카테고리</span>
+                </div>
+                <div>
+                   게시시간 <span class="uploadTime" th:text="${product.createTime}">게시시간</span>
+                </div>
+                <div>
+                    본문 <div class="cont" th:text="${product.caption}">본문</div>
+                </div>
+                <div>
+                    관심 <div class="likes"> n</div>
+                </div>
             </div>
         </section>
         <!-- sec_02 -->
         <section id="sec_03">
             <div class="product_caption clear">
-                <strong>닉네님의 판매 상품</strong>
+                <strong th:text="${product.nickName}">닉네님</strong>의 판매 상품
                 <a class="showall" href="/product/all" >모두보기</a>
             </div>
             <div class="products">
-                <a>
-                    <img src="/img/product01.png" alt="상품이미지01">
-                    <span>제목</span>
-                    <span>가격</span>
-                </a>
-                <a>
-                    <img src="/img/product02.png" alt="상품이미지02">
-                    <span>제목</span>
-                    <span>가격</span>
-                </a>
-                <a>
-                    <img src="/img/product03.png" alt="상품이미지03">
-                    <span>제목</span>
-                    <span>가격</span>
-                </a>
-                <a>
-                    <img src="/img/product04.png" alt="상품이미지04">
-                    <span>제목</span>
-                    <span>가격</span>
-                </a>
+                <div th:each="prod : ${product.t4Prods}">
+                    <a>
+                        <img src="/img/product01.png" th:src="${prod.coverImage}" alt="상품이미지01">
+                    </a>
+                    <span th:text="${prod.title}">제목</span>
+                    <span th:text="${prod.price}">가격</span>
+                </div>
             </div>
+            <!-- content -->
         </section>
         <!-- sec_03 -->
         <section id="sec_04">

--- a/back/src/test/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImplTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImplTest.java
@@ -2,9 +2,12 @@ package com.t1dmlgus.daangnClone.product.application;
 
 import com.t1dmlgus.daangnClone.product.domain.Product;
 import com.t1dmlgus.daangnClone.product.domain.ProductRepository;
+import com.t1dmlgus.daangnClone.product.domain.SaleStatus;
+import com.t1dmlgus.daangnClone.product.ui.dto.ProductRequestDto;
+import com.t1dmlgus.daangnClone.user.domain.Role;
 import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
-import com.t1dmlgus.daangnClone.user.ui.dto.product.ProductRequestDto;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,7 +17,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.assertj.core.api.Assertions.*;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -24,7 +30,6 @@ import static org.mockito.Mockito.doReturn;
 @ExtendWith(MockitoExtension.class)
 class ProductServiceImplTest {
 
-
     @InjectMocks
     private ProductServiceImpl productServiceImpl;
 
@@ -32,26 +37,46 @@ class ProductServiceImplTest {
     private ProductRepository productRepository;
     @Mock
     private S3Service s3service;
-    
+
+    private static User testUser;
+    private static Product testProduct;
+    private static ProductRequestDto productRequestDto;
+    private static MockMultipartFile file;
+
+    @BeforeAll
+    static void beforeAll() {
+        testUser = new User(1L, "dmlgusgngl@gmail.com", "1234", "이의현", "010-1234-1234", "t1dmlgus", Role.ROLE_USER);
+        testProduct = new Product(1L, "상품명", null, 2000, "상품내용", SaleStatus.SALE, testUser);
+        productRequestDto = new ProductRequestDto("상품명", null, 100, "상품내용");
+        file = new MockMultipartFile("파일명", "파일명.jpeg", "image/jpeg", "파일12".getBytes());
+    }
+
     @DisplayName("서비스 - 상품 등록 테스트")
     @Test
-    public void registerTest() throws Exception{
+    public void registerTest() throws Exception {
         //given
-
-        ProductRequestDto productRequestDto = new ProductRequestDto("상품명",null,100,"상품내용");
-        MockMultipartFile file = new MockMultipartFile("파일명", "파일명.jpeg", "image/jpeg", "파일12".getBytes());
-
         doReturn(new Product()).when(productRepository).save(any());
-        doNothing().when(s3service).upload(any(),any());
+        doNothing().when(s3service).upload(any(), any());
 
         //when
-        ResponseDto<?> responseDto = productServiceImpl.registerProduct(productRequestDto, file, new User());
-
+        ResponseDto<?> responseDto = productServiceImpl.registerProduct(productRequestDto, file, testUser);
         //then
         assertThat(responseDto.getMessage()).isEqualTo("상품이 등록되었습니다.");
-        
-        
     }
-    
-    
+
+    @DisplayName("서비스 - 상품 조회 테스트")
+    @Test
+    public void InquiryProductTest() throws Exception {
+        //given
+        doReturn(Optional.of(testProduct)).when(productRepository).findById(any(Long.class));
+        doReturn(new ArrayList<>()).when(s3service).inquiryProductImage(any(Long.class));
+
+        //when
+        ResponseDto<?> product = productServiceImpl.inquiryProduct(testProduct.getId());
+        //then
+        assertThat(product.getMessage()).isEqualTo("조회한 상품입니다.");
+
+    }
+
+
 }

--- a/back/src/test/java/com/t1dmlgus/daangnClone/product/application/S3ServiceUnitTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/product/application/S3ServiceUnitTest.java
@@ -1,27 +1,23 @@
 package com.t1dmlgus.daangnClone.product.application;
 
-import com.t1dmlgus.daangnClone.handler.exception.CustomApiException;
 import com.t1dmlgus.daangnClone.product.domain.Image;
 import com.t1dmlgus.daangnClone.product.domain.ImageRepository;
 import com.t1dmlgus.daangnClone.product.domain.Product;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doReturn;
 
 
 @Transactional

--- a/back/src/test/java/com/t1dmlgus/daangnClone/product/ui/ProductApiControllerTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/product/ui/ProductApiControllerTest.java
@@ -4,6 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.t1dmlgus.daangnClone.auth.WithMockCustomUser;
 import com.t1dmlgus.daangnClone.auth.domain.PrincipalDetails;
 import com.t1dmlgus.daangnClone.product.application.ProductService;
+import com.t1dmlgus.daangnClone.product.domain.Product;
+import com.t1dmlgus.daangnClone.product.domain.SaleStatus;
+import com.t1dmlgus.daangnClone.product.ui.dto.InquiryProductResponseDto;
+import com.t1dmlgus.daangnClone.product.ui.dto.InquiryProductTopFourResponseDto;
+import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,11 +23,13 @@ import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.t1dmlgus.daangnClone.common.ApiDocumentUtils.getDocumentRequest;
 import static com.t1dmlgus.daangnClone.common.ApiDocumentUtils.getDocumentResponse;
@@ -30,6 +37,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -85,7 +93,36 @@ class ProductApiControllerTest {
                 ));
     }
 
-    
+    @DisplayName("컨트롤러 - 상품조회 테스트")
+    @Test
+    @WithMockCustomUser
+    public void inquiryProductTest() throws Exception{
+        //given
+        Long productId = 21L;
+        Product testProduct = new Product(21L, "상품명", null, 2000, "상품내용", SaleStatus.SALE, new User());
+        List<String> productImages = new ArrayList<>();
+        List<InquiryProductTopFourResponseDto> t4Prod = new ArrayList<>();
+
+        InquiryProductResponseDto inquiryProductResponseDto = new InquiryProductResponseDto(testProduct, productImages, t4Prod);
+
+        doReturn(new ResponseDto<>("조회한 상품입니다.", inquiryProductResponseDto))
+                .when(productService).inquiryProduct(productId);
+
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/product/{productId}", productId)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse()));
+    }
+
 
 
 }


### PR DESCRIPTION
### 이슈번호
#21 

### 개요

- 상품 조회 API 구현
- 상품 페이지 렌더링


### 작업 내용

ProductServiceImpl.java

- 해당 상품에 대한 정보와 상품 이미지 리스트를 가져와 상품에 대한 데이터를 반환
- 이미지 리스트는 S3service를 사용
- 해당 유저가 판매하는 상품 4개도 같이 반환

S3Service.java

- 상품 이미지 조회 시, .stream.map을 이용하여 해당 파일 이미지만 List<String> 타입으로 반환
- S3 버킷과 CloudFront와 연동하여 이미지를 출력할 수 있도록, DB에 CloutFrornt 주소와 FileName을 같이 String 타입으로 저장하도록 리펙토링

ProductRepository.java

- native 쿼리를 이용하여, 해댱 유저가 등록한 상품 중 최근 등록 상품 4개를 가져오는 sql 생성

InquiryProductResponseDto

- 상품 페이지 렌더링을 위해 Dto 생성
  필드(제목, 가격, 카테고리, 게시시간, 상태, 닉네임, 본문, 이미지리스트, 최신 등록상품 4개)

product.html

- thymeleaf 를 이용하여 해당 데이터 렌더링
- 게시시간 -> 1일전, 23분전 등 리펙토링 필요
- 좋아요, 댓글 기능 추가 필요



### 테스트

- [x] ProductServiceImplTest
- [x] ProductApiControllerTest


### 주의사항

- native 쿼리 -> 추후 querydsl 리펙토링
- 순환참조 트러블 슈팅



