### PR TITLE
[BE] 카테고리 별 조회[ISSUE-43]

### DIFF
--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductService.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductService.java
@@ -1,5 +1,6 @@
 package com.t1dmlgus.daangnClone.product.application;
 
+import com.t1dmlgus.daangnClone.product.domain.Category;
 import com.t1dmlgus.daangnClone.product.ui.dto.ProductRequestDto;
 import com.t1dmlgus.daangnClone.user.domain.User;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
@@ -17,6 +18,9 @@ public interface ProductService {
 
     // 전체 상품 조회(최신순)
     ResponseDto<?> allProduct(Long userId, Pageable pageable);
+
+    // 카테고리 별 조회
+    ResponseDto<?> categoryProduct(Category category, Long userId, Pageable pageable);
 
 
     // 상품 수정

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImpl.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImpl.java
@@ -3,10 +3,11 @@ package com.t1dmlgus.daangnClone.product.application;
 import com.t1dmlgus.daangnClone.handler.exception.CustomApiException;
 import com.t1dmlgus.daangnClone.likes.application.LikesService;
 import com.t1dmlgus.daangnClone.likes.ui.dto.ProductLikesStatus;
+import com.t1dmlgus.daangnClone.product.domain.Category;
 import com.t1dmlgus.daangnClone.product.domain.Product;
 import com.t1dmlgus.daangnClone.product.domain.ProductRepository;
 import com.t1dmlgus.daangnClone.product.ui.ProductApiController;
-import com.t1dmlgus.daangnClone.product.ui.dto.AllProductResponseDto;
+import com.t1dmlgus.daangnClone.product.ui.dto.ProductResponseDto;
 import com.t1dmlgus.daangnClone.product.ui.dto.InquiryProductResponseDto;
 import com.t1dmlgus.daangnClone.product.ui.dto.InquiryProductTopFourResponseDto;
 import com.t1dmlgus.daangnClone.product.ui.dto.ProductRequestDto;
@@ -16,6 +17,7 @@ import com.t1dmlgus.daangnClone.util.RegisterProductTimeFromNow;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -74,7 +76,7 @@ public class ProductServiceImpl implements ProductService{
     @Override
     public ResponseDto<?> allProduct(Long userId, Pageable pageable) {
 
-        List<AllProductResponseDto> allProductDtos = new ArrayList<>();
+        List<ProductResponseDto> allProductDtos = new ArrayList<>();
 
         for (Product product : productRepository.findAll(pageable)) {
 
@@ -88,9 +90,30 @@ public class ProductServiceImpl implements ProductService{
             String coverImage = getCoverImage(product.getId());
 
             // 4. 랜딩 페이지 List<Dto>
-            allProductDtos.add(new AllProductResponseDto(product, registerTime, productLikesStatus, coverImage));
+            allProductDtos.add(new ProductResponseDto(product, registerTime, productLikesStatus, coverImage));
         }
         return new ResponseDto<>("상품을 전체 조회합니다.", allProductDtos);
+    }
+
+    @Override
+    public ResponseDto<?> categoryProduct(Category category,Long userId, Pageable pageable) {
+
+        List<ProductResponseDto> categoryByProductDtos = new ArrayList<>();
+
+        Page<Product> productByCategory = productRepository.findByCategory(category, pageable);
+
+        for (Product product : productByCategory) {
+            // 1. 몇분 전
+            String registerTime = getRegisterProduct(product.getCreatedDate());
+            // 2. 커버 이미지
+            String coverImage = getCoverImage(product.getId());
+            // 3. 좋아요 정보(상태, 카운트)
+            ProductLikesStatus productLikesStatus = getProductLikesStatus(userId, product.getId());
+            // 4. 카테고리 상품 DTO
+            categoryByProductDtos.add(new ProductResponseDto(product, registerTime,productLikesStatus, coverImage));
+        }
+
+        return new ResponseDto<>("카테고리 별로 조회합니다.", categoryByProductDtos);
     }
 
 

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/ProductRepository.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/domain/ProductRepository.java
@@ -1,5 +1,7 @@
 package com.t1dmlgus.daangnClone.product.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +15,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "order by created_date desc\n" +
             "LIMIT 4", nativeQuery = true)
     List<Product> inquiryProductTopFourByUser(@Param("productId") Long productId, @Param("userId") Long userId);
+
+
+    Page<Product> findByCategory(Category category, Pageable pageable);
+
+
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductApiController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductApiController.java
@@ -2,6 +2,7 @@ package com.t1dmlgus.daangnClone.product.ui;
 
 import com.t1dmlgus.daangnClone.auth.domain.PrincipalDetails;
 import com.t1dmlgus.daangnClone.product.application.ProductService;
+import com.t1dmlgus.daangnClone.product.domain.Category;
 import com.t1dmlgus.daangnClone.product.ui.dto.ProductRequestDto;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,6 @@ public class ProductApiController {
 
         ResponseDto<?> registerDto = productService.registerProduct(productRequestDto, file, principalDetails.getUser());
         logger.info(SecurityContextHolder.getContext().toString());
-
         return new ResponseEntity<>(registerDto, HttpStatus.CREATED);
     }
 
@@ -41,22 +41,25 @@ public class ProductApiController {
     public ResponseEntity<?> inquiryProduct(@PathVariable Long productId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         ResponseDto<?> productDetailDto = productService.inquiryProduct(productId, principalDetails.getUser().getId());
-
         return new ResponseEntity<>(productDetailDto, HttpStatus.OK);
 
     }
-
 
     // 상품 전체 조회, 페이징 적용
     @GetMapping("/randing")
     public ResponseEntity<?> allProduct(@AuthenticationPrincipal PrincipalDetails principalDetails, @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
         ResponseDto<?> allProductDtos = productService.allProduct(principalDetails.getUser().getId(), pageable);
-
         return new ResponseEntity<>(allProductDtos, HttpStatus.OK);
-
     }
 
+    // 카테고리 조회, 페이징 적용
+    @GetMapping("/category/{category}")
+    public ResponseEntity<?> allProduct(@PathVariable Category category, @AuthenticationPrincipal PrincipalDetails principalDetails, @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        ResponseDto<?> product = productService.categoryProduct(category,principalDetails.getUser().getId(), pageable);
+        return new ResponseEntity<>(product, HttpStatus.OK);
+    }
 
     
     

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductController.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/ProductController.java
@@ -2,6 +2,7 @@ package com.t1dmlgus.daangnClone.product.ui;
 
 import com.t1dmlgus.daangnClone.auth.domain.PrincipalDetails;
 import com.t1dmlgus.daangnClone.product.application.ProductService;
+import com.t1dmlgus.daangnClone.product.domain.Category;
 import com.t1dmlgus.daangnClone.user.ui.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -62,5 +63,26 @@ public class ProductController {
     public String registerProduct(){
         return "product/register";
     }
+
+    // 카테고리 메뉴
+    @GetMapping("category")
+    public String categoryMenu(){
+        return "product/categoryMenu";
+    }
+
+    // 카테고리 페이지
+    @GetMapping("/category/{category}")
+    public String byCategory(@PathVariable Category category,@AuthenticationPrincipal PrincipalDetails principalDetails, @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable, Model model) {
+
+        System.out.println("category = " + category);
+        ResponseDto<?> productByCategoryDtos = productService.categoryProduct(category, principalDetails.getUser().getId(), pageable);
+
+        logger.info("product, {}", productByCategoryDtos.getData());
+        model.addAttribute("product", productByCategoryDtos.getData());
+        model.addAttribute("category", category);
+
+        return "product/category";
+    }
+
 
 }

--- a/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/dto/ProductResponseDto.java
+++ b/back/src/main/java/com/t1dmlgus/daangnClone/product/ui/dto/ProductResponseDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class AllProductResponseDto {
+public class ProductResponseDto {
 
     private Long productId;
     private String title;
@@ -22,7 +22,9 @@ public class AllProductResponseDto {
 
     private String coverImage;
 
-    public AllProductResponseDto(Product product,String registerTime, ProductLikesStatus productLikesStatus, String coverImage) {
+
+    // 랜딩 dto
+    public ProductResponseDto(Product product, String registerTime, ProductLikesStatus productLikesStatus, String coverImage) {
         this.productId = product.getId();
         this.title = product.getTitle();
         this.price = product.getPrice();

--- a/back/src/main/resources/static/css/category.css
+++ b/back/src/main/resources/static/css/category.css
@@ -1,0 +1,16 @@
+.container{position: relative;}
+
+
+.back{position: absolute;left: 10px;top: 15px; display: inline-block; width: 46px;}
+.back img{width: 20px;}
+/* back */
+
+
+.category{padding: 20px 0;font-size:20px; font-weight:bold; text-align:center}
+.category >div{}
+
+
+
+#sec01 >div{width: 90%; margin: 0 auto; text-align: center}
+#sec01 >div> ul li{display: inline-block; width:30%}
+#sec01 >div> ul li a{line-height:50px;height: 50px;margin: 20px 5px;display: block;background: #c0c0c0;border: 1px solid;}

--- a/back/src/main/resources/templates/product/category.html
+++ b/back/src/main/resources/templates/product/category.html
@@ -11,12 +11,12 @@
 
     <link rel="stylesheet" href="/css/default.css">
     <link rel="stylesheet" href="/css/randing.css">
-    <title>랜딩페이지</title>
+    <title>카테고리 페이지</title>
 </head>
 <body>
     <div class="container">
         <section id="sec_header">
-            <h3 th:text="${user.place}">개발자</h3>
+            <h3 th:text="${category.krName}">카테고리</h3>
             <div class="clear">
                 <a onclick="callFunction();">
                     <img src="/img/search.png" alt="검색">

--- a/back/src/main/resources/templates/product/categoryMenu.html
+++ b/back/src/main/resources/templates/product/categoryMenu.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+
+    <!-- 제이쿼리 -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- css -->
+    <link rel="stylesheet" href="/css/default.css">
+    <link rel="stylesheet" href="/css/category.css">
+    <title>상품페이지</title>
+</head>
+<body>
+<div class="container">
+    <a href="/product/randing" class="back">
+        <img src="/img/left-arrow.png" alt="화살표">
+        <img src="/img/home.png" alt="home">
+    </a>
+    <div class="category">
+        <div>카테고리</div>
+    </div>
+    <section id="sec01">
+        <div>
+            <ul>
+                <li>
+                    <a href="/product/category/">인기매물</a>
+                </li>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'USED_CAR')}">중고차</a>
+                </li>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'DIGITAL_DEVICE')}">디지털기기</a>
+                </li>
+            </ul>
+        </div>
+        <div>
+            <ul>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'HOME_APPLIANCES')}">생활가전</a>
+                </li>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'FURNITURE_INTERIOR')}">가구/인테리어</a>
+                </li>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'CHILD')}">유아동</a>
+                </li>
+            </ul>
+        </div>
+        <div>
+            <ul>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'LIFE_PROCESSED_FOOD')}">생활/가공식품</a>
+                </li>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'CHILDREN_BOOKS')}">유아도서</a>
+                </li>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'BEAUTY')}">뷰티</a>
+                </li>
+            </ul>
+        </div>
+        <div>
+            <ul>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'WOMEN_CLOTHING')}">여성의류</a>
+                </li>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'MEN_CLOTHING')}">남성의류</a>
+                </li>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'PET_SUPPLIES')}">반려동물용품</a>
+                </li>
+            </ul>
+        </div>
+        <div>
+            <ul>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'BOOK_TICKET_ALBUM')}">도서/티켓/음반</a>
+                </li>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'PLANT')}">식물</a>
+                </li>
+                <li>
+                    <a th:href="@{/product/category/{category}(category = 'OTHER_USED_GOODS')}">기타 중고물품</a>
+                </li>
+            </ul>
+        </div>
+        <div>
+            <ul>
+                <li>
+                    <a href="#">도서/티켓/음반</a>
+                </li>
+                <li>
+                    <a href="#">식물</a>
+                </li>
+                <li>
+                    <a href="#">기타 중고물품</a>
+                </li>
+            </ul>
+        </div>
+    </section>
+    <!-- sec_04 -->
+</div>
+<script src="/js/product.js"></script>
+</body>
+
+</html>

--- a/back/src/main/resources/templates/product/product.html
+++ b/back/src/main/resources/templates/product/product.html
@@ -16,7 +16,7 @@
 </head>
 <body>
     <div class="container">
-        <a href="/product/randing" class="back">
+        <a href="#" onClick="history.back()" class="back">
             <img src="/img/left-arrow.png" alt="화살표">
             <img src="/img/home.png" alt="home">
         </a>
@@ -40,7 +40,7 @@
                     <span class="title" th:text="${product.title}">제목</span>
                 </div>
                 <div class="gray">
-                    <span class="category" th:text="${product.category.krName}">카테고리</span>
+                    <span class="category" th:val="${product.category}" th:text="${product.category.krName}">카테고리</span>
                     <span>*</span>
                     <span class="uploadTime" th:text="${product.registerTime}">게시시간</span>
                 </div>

--- a/back/src/test/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImplTest.java
+++ b/back/src/test/java/com/t1dmlgus/daangnClone/product/application/ProductServiceImplTest.java
@@ -2,6 +2,7 @@ package com.t1dmlgus.daangnClone.product.application;
 
 import com.t1dmlgus.daangnClone.likes.application.LikesService;
 import com.t1dmlgus.daangnClone.likes.ui.dto.ProductLikesStatus;
+import com.t1dmlgus.daangnClone.product.domain.Category;
 import com.t1dmlgus.daangnClone.product.domain.Product;
 import com.t1dmlgus.daangnClone.product.domain.ProductRepository;
 import com.t1dmlgus.daangnClone.product.domain.SaleStatus;
@@ -57,7 +58,7 @@ class ProductServiceImplTest {
     @BeforeAll
     static void beforeAll() {
         testUser = new User(1L, "dmlgusgngl@gmail.com", "1234", "이의현", "010-1234-1234", "t1dmlgus", Role.ROLE_USER, "박달1동");
-        testProduct = new Product(1L, "상품명", null, 2000, "상품내용", SaleStatus.SALE, testUser);
+        testProduct = new Product(1L, "상품명", Category.BEAUTY, 2000, "상품내용", SaleStatus.SALE, testUser);
         productRequestDto = new ProductRequestDto("상품명", "PET_SUPPLIES", 100, "상품내용");
         file = new MockMultipartFile("파일명", "파일명.jpeg", "image/jpeg", "파일12".getBytes());
 
@@ -138,6 +139,28 @@ class ProductServiceImplTest {
         //then
         assertThat(time).isEqualTo("50초 전");
 
+    }
+
+    @DisplayName("서비스 - 카테고리 별 상품 조회 테스트")
+    @Test
+    public void productByCategoryTest() throws Exception{
+        //given
+        // 상품 리스트 페이징
+        PageRequest of = PageRequest.of(0, 5);
+        Page<Product> p = new PageImpl<>(new ArrayList<>(List.of(testProduct, testProduct)));
+        // 전체 상품 조회
+        when(productRepository.findByCategory(Category.BEAUTY, of)).thenReturn(p);
+        // 해당 상품 좋아요 상태
+        when(likesService.productLikesStatus(testProduct.getId(), testUser.getId()))
+                .thenReturn(new ProductLikesStatus(true, 5));
+        // 해당 상품 이미지 리스트 조회
+        when(s3service.inquiryProductImage(anyLong()))
+                .thenReturn(new ArrayList<>(List.of("testImage01", "testImage02", "testImage03")));
+
+        //when
+        ResponseDto<?> allProductDtos = productServiceImpl.categoryProduct(Category.BEAUTY, testUser.getId(), of);
+        //then
+        assertThat(allProductDtos.getMessage()).isEqualTo("카테고리 별로 조회합니다.");
     }
 
 }


### PR DESCRIPTION
### 이슈번호
resolved: #43 

### 개요

카테고리 별 조회 기능 구현

### 작업 내용

ProductServiceImpl.java

- ProductService를 상속받아 카테고리 별 상품조회 기능을 구현한다. 
- 일반 상품 조회와 비즈니스 로직 순서는 같으며, ProductRepository에서 findByCategory 쿼리 메소드를 사용하여, 컨트롤러에서 넘어온 enum 타입의 카테고리 종류를 조건으로  카테고리 별 상품을 조회한다.

ProductController.java, ProductApiController.java

- 컨트롤러 메소드 인수로는 @PathVariable Category 타입으로 받아, ProductService 를 실행한다.


### 테스트

- [ ] ProductApiControllerTest.java
- [x] ProductServiceImplTest.java


### 주의사항

ProductApiControllerTest.java에서 카테고리 별 상품 조회 테스트 시, body 값이 바인딩이 안되는 버그가 남
 - doReturn으로 data에 해당하는 객체 생성했음

![image](https://user-images.githubusercontent.com/59961350/151669763-9bacb3d3-64a7-4fac-93b5-1b37f74ccfcb.png)

![image](https://user-images.githubusercontent.com/59961350/151669827-35266eeb-1e6a-4c34-aa0d-e9537b642804.png)



 

